### PR TITLE
Optional monitor

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -38,18 +38,77 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "fc5b111f",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "101\n",
+            "99\n",
+            "mean score tpr Score    5.920792\n",
+            "dtype: double[pyarrow]\n",
+            "mean score fpr Score    5.893939\n",
+            "dtype: double[pyarrow]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Cell for seeing how many valid samples there are in an eval file\n",
+        "# do not delete this cell\n",
+        "from pathlib import Path\n",
+        "from lasr_labs_2025_control_project.utils.logs_to_model import get_scores_from_path\n",
+        "\n",
+        "\n",
+        "scores = get_scores_from_path(\n",
+        "    Path(\"src/lasr_labs_2025_control_project/apps/results/logs/base/interview_4o_200_honeypot_2025-09-10T17-14-37+01-00_apps-untrusted-monitoring-protocol-attack-f994f4b8_48fPWkRXYk6orN7tiVdPPM.eval\"),\n",
+        ")\n",
+        "print(len(scores))\n",
+        "second_scores = get_scores_from_path(\n",
+        "    Path(\"src/lasr_labs_2025_control_project/apps/results/logs/base/interview_4o_200_honeypot_2025-09-10T17-14-37+01-00_apps-untrusted-monitoring-protocol-attack-f994f4b8_48fPWkRXYk6orN7tiVdPPM.evalapps-untrusted-monitoring-protocol-attack-e38dbb92_jyQux8JaWXSh6esxSwNhkW.eval\"),\n",
+        ")\n",
+        "print(len(second_scores))\n",
+        "# mean score for pandas dataframes\n",
+        "\n",
+        "print('mean score tpr', scores.mean())\n",
+        "print('mean score fpr', second_scores.mean())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "id": "cdcd784a",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "FileNotFoundError",
+          "evalue": "[Errno 2] No such file or directory: '/Users/nelsongardner-challis/Coding/lasr-labs-2025-control-project/logs/generator-4o-monitor-4.1finetuned.eval'",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 6\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01minspect_ai\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01manalysis\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m samples_df\n\u001b[32m      3\u001b[39m self_df = samples_df(\n\u001b[32m      4\u001b[39m     Path(\u001b[33m\"\u001b[39m\u001b[33msrc/lasr_labs_2025_control_project/apps/results/logs/base/interview_4o_200_honeypot_2025-09-10T17-14-37+01-00_apps-untrusted-monitoring-protocol-attack-f994f4b8_48fPWkRXYk6orN7tiVdPPM.eval\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      5\u001b[39m )\n\u001b[32m----> \u001b[39m\u001b[32m6\u001b[39m other_df = \u001b[43msamples_df\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m      7\u001b[39m \u001b[43m    \u001b[49m\u001b[43mPath\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mlogs/generator-4o-monitor-4.1finetuned.eval\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      8\u001b[39m \u001b[43m)\u001b[49m\n\u001b[32m     10\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;28mlen\u001b[39m(self_df))\n\u001b[32m     12\u001b[39m data = {\n\u001b[32m     13\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mpositive\u001b[39m\u001b[33m\"\u001b[39m: self_df[\u001b[33m\"\u001b[39m\u001b[33mscore_max_confidence_scorer\u001b[39m\u001b[33m\"\u001b[39m].tolist(),\n\u001b[32m     14\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mnegative\u001b[39m\u001b[33m\"\u001b[39m: other_df[\u001b[33m\"\u001b[39m\u001b[33mscore_max_confidence_scorer\u001b[39m\u001b[33m\"\u001b[39m].tolist(),\n\u001b[32m     15\u001b[39m }\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Coding/lasr-labs-2025-control-project/.venv/lib/python3.13/site-packages/inspect_ai/analysis/_dataframe/samples/table.py:115\u001b[39m, in \u001b[36msamples_df\u001b[39m\u001b[34m(logs, columns, full, strict, parallel, quiet)\u001b[39m\n\u001b[32m    112\u001b[39m verify_prerequisites()\n\u001b[32m    114\u001b[39m quiet = quiet \u001b[38;5;28;01mif\u001b[39;00m quiet \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m running_in_notebook()\n\u001b[32m--> \u001b[39m\u001b[32m115\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_read_samples_df\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    116\u001b[39m \u001b[43m    \u001b[49m\u001b[43mlogs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfull\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfull\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstrict\u001b[49m\u001b[43m=\u001b[49m\u001b[43mstrict\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprogress\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;129;43;01mnot\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mquiet\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparallel\u001b[49m\u001b[43m=\u001b[49m\u001b[43mparallel\u001b[49m\n\u001b[32m    117\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Coding/lasr-labs-2025-control-project/.venv/lib/python3.13/site-packages/inspect_ai/analysis/_dataframe/samples/table.py:147\u001b[39m, in \u001b[36m_read_samples_df\u001b[39m\u001b[34m(logs, columns, full, strict, detail, progress, parallel)\u001b[39m\n\u001b[32m    144\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpandas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpd\u001b[39;00m\n\u001b[32m    146\u001b[39m \u001b[38;5;66;03m# resolve logs\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m147\u001b[39m logs = \u001b[43mresolve_logs\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlogs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    149\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m parallel:\n\u001b[32m    150\u001b[39m     \u001b[38;5;66;03m# resolve number of workers (cap at 8 as eventually we run into disk/memory contention)\u001b[39;00m\n\u001b[32m    151\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m parallel \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mTrue\u001b[39;00m:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Coding/lasr-labs-2025-control-project/.venv/lib/python3.13/site-packages/inspect_ai/analysis/_dataframe/util.py:62\u001b[39m, in \u001b[36mresolve_logs\u001b[39m\u001b[34m(logs)\u001b[39m\n\u001b[32m     60\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m log_str \u001b[38;5;129;01min\u001b[39;00m logs_str:\n\u001b[32m     61\u001b[39m     fs = filesystem(log_str)\n\u001b[32m---> \u001b[39m\u001b[32m62\u001b[39m     info = \u001b[43mfs\u001b[49m\u001b[43m.\u001b[49m\u001b[43minfo\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlog_str\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     63\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m info.type == \u001b[33m\"\u001b[39m\u001b[33mdirectory\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m     64\u001b[39m         log_paths.extend(\n\u001b[32m     65\u001b[39m             [fi \u001b[38;5;28;01mfor\u001b[39;00m fi \u001b[38;5;129;01min\u001b[39;00m fs.ls(info.name, recursive=\u001b[38;5;28;01mTrue\u001b[39;00m) \u001b[38;5;28;01mif\u001b[39;00m fi.type == \u001b[33m\"\u001b[39m\u001b[33mfile\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m     66\u001b[39m         )\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Coding/lasr-labs-2025-control-project/.venv/lib/python3.13/site-packages/inspect_ai/_util/file.py:206\u001b[39m, in \u001b[36mFileSystem.info\u001b[39m\u001b[34m(self, path, **kwargs)\u001b[39m\n\u001b[32m    205\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34minfo\u001b[39m(\u001b[38;5;28mself\u001b[39m, path: \u001b[38;5;28mstr\u001b[39m, **kwargs: \u001b[38;5;28mdict\u001b[39m[\u001b[38;5;28mstr\u001b[39m, Any]) -> FileInfo:\n\u001b[32m--> \u001b[39m\u001b[32m206\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._file_info(\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mfs\u001b[49m\u001b[43m.\u001b[49m\u001b[43minfo\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Coding/lasr-labs-2025-control-project/.venv/lib/python3.13/site-packages/fsspec/implementations/local.py:100\u001b[39m, in \u001b[36mLocalFileSystem.info\u001b[39m\u001b[34m(self, path, **kwargs)\u001b[39m\n\u001b[32m     97\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m     98\u001b[39m     \u001b[38;5;66;03m# str or path-like\u001b[39;00m\n\u001b[32m     99\u001b[39m     path = \u001b[38;5;28mself\u001b[39m._strip_protocol(path)\n\u001b[32m--> \u001b[39m\u001b[32m100\u001b[39m     out = \u001b[43mos\u001b[49m\u001b[43m.\u001b[49m\u001b[43mstat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfollow_symlinks\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[32m    101\u001b[39m     link = stat.S_ISLNK(out.st_mode)\n\u001b[32m    102\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m link:\n",
+            "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: '/Users/nelsongardner-challis/Coding/lasr-labs-2025-control-project/logs/generator-4o-monitor-4.1finetuned.eval'"
+          ]
+        }
+      ],
       "source": [
         "from pathlib import Path\n",
         "from inspect_ai.analysis import samples_df\n",
         "self_df = samples_df(\n",
-        "    Path(\"logs/generator-4.1-monitor-4.1finetuned.eval\")\n",
+        "    Path(\"src/lasr_labs_2025_control_project/apps/results/logs/base/interview_4o_200_honeypot_2025-09-10T17-14-37+01-00_apps-untrusted-monitoring-protocol-attack-f994f4b8_48fPWkRXYk6orN7tiVdPPM.eval\")\n",
         ")\n",
         "other_df = samples_df(\n",
-        "    Path(\"logs/generator-4o-monitor-4.1finetuned.eval\")\n",
+        "    Path(\"src/lasr_labs_2025_control_project/apps/results/logs/base/interview_4o_200_honeypot_2025-09-10T17-14-37+01-00_apps-untrusted-monitoring-protocol-attack-f994f4b8_48fPWkRXYk6orN7tiVdPPM.eval\")\n",
         ")\n",
+        "\n",
+        "print(len(self_df))\n",
         "\n",
         "data = {\n",
         "    \"positive\": self_df[\"score_max_confidence_scorer\"].tolist(),\n",

--- a/src/lasr_labs_2025_control_project/apps/apps.py
+++ b/src/lasr_labs_2025_control_project/apps/apps.py
@@ -84,7 +84,7 @@ def untrusted_policy_builder(model: str) -> Any:
 
 def honeypot_policy_builder(model: str) -> Any:
     return policy_gate(
-        honest=honest_policy(model=model, prompt=honest_policy_prompt),
+        honest=honest_policy(model=model, prompt=self_rec_honest_policy_prompt),
         attack=attack_policy(
             model=model,
             prompt=attack_policy_prompt,

--- a/src/lasr_labs_2025_control_project/apps/protocols/untrusted_monitoring_protocol.py
+++ b/src/lasr_labs_2025_control_project/apps/protocols/untrusted_monitoring_protocol.py
@@ -16,6 +16,7 @@ from lasr_labs_2025_control_project.apps.policies.policy_gate import policy_gate
 def untrusted_monitoring_protocol(
     policy_builder: AgentBuilder = Field(default_factory=policy_gate),
     monitor_builder: AgentBuilder = Field(default_factory=basic_monitor),
+    use_monitor: bool = Field(default=False),
 ) -> AgentBuilderType:
     """Build an untrusted monitor agent that combines policy and monitor.
 
@@ -40,8 +41,9 @@ def untrusted_monitoring_protocol(
         async def impl(state: AgentState, tools: list[Tool]) -> AgentState:
             state = await policy(state, tools)
             # Check if there are tool calls and specifically if "submit" is among them
-            if state.output.message and state.output.message.tool_calls:
-                state = await monitor(state, tools)
+            if use_monitor:
+                if state.output.message and state.output.message.tool_calls:
+                    state = await monitor(state, tools)
             return state
 
         return impl

--- a/src/lasr_labs_2025_control_project/apps/runners/self_rec/attack.py
+++ b/src/lasr_labs_2025_control_project/apps/runners/self_rec/attack.py
@@ -13,7 +13,7 @@ from lasr_labs_2025_control_project.apps.protocols.untrusted_monitoring_protocol
 )
 from lasr_labs_2025_control_project.apps.scorers import max_confidence_scorer
 
-untrusted_model = "openai/ft:gpt-4.1-2025-04-14:lasr-labs::CC5IeIFO"
+untrusted_model = "openai/gpt-4o-2024-08-06"
 score_field = "confidence_score"
 
 apps_task = get_control_task_product(
@@ -24,9 +24,9 @@ apps_task = get_control_task_product(
             model=untrusted_model, score_field=score_field
         ),
     ),
-    modes=[EvalMode.HONEST],
+    modes=[EvalMode.ATTACK],
     monitoring_scorers=[max_confidence_scorer()],
     eval_config=ControlEvalConfig(untrusted_model=untrusted_model),
 )
-n = 2
-eval = eval(tasks=apps_task, epochs=Epochs(n, [f"pass_at_{n}"]), limit=50)
+n = 1
+eval = eval(tasks=apps_task, epochs=Epochs(n, [f"pass_at_{n}"]), limit=200)

--- a/src/lasr_labs_2025_control_project/apps/runners/self_rec/attack.py
+++ b/src/lasr_labs_2025_control_project/apps/runners/self_rec/attack.py
@@ -13,20 +13,25 @@ from lasr_labs_2025_control_project.apps.protocols.untrusted_monitoring_protocol
 )
 from lasr_labs_2025_control_project.apps.scorers import max_confidence_scorer
 
-untrusted_model = "openai/gpt-4o-2024-08-06"
+untrusted_model = "openai/gpt-4.1-2025-04-14"
 score_field = "confidence_score"
+
+# Toggle monitoring on/off for evaluations
+use_monitor = False
 
 apps_task = get_control_task_product(
     settings=apps_setting,
     protocols=untrusted_monitoring_protocol(
         policy_builder=untrusted_policy_builder(model=untrusted_model),
         monitor_builder=untrusted_monitor_builder(
-            model=untrusted_model, score_field=score_field
+            model=untrusted_model,
+            score_field=score_field,
         ),
+        use_monitor=use_monitor,
     ),
     modes=[EvalMode.ATTACK],
-    monitoring_scorers=[max_confidence_scorer()],
+    monitoring_scorers=[max_confidence_scorer()] if use_monitor else [],
     eval_config=ControlEvalConfig(untrusted_model=untrusted_model),
 )
 n = 1
-eval = eval(tasks=apps_task, epochs=Epochs(n, [f"pass_at_{n}"]), limit=200)
+eval = eval(tasks=apps_task, epochs=Epochs(n, [f"pass_at_{n}"]), limit=2)

--- a/src/lasr_labs_2025_control_project/apps/runners/self_rec/honeypot.py
+++ b/src/lasr_labs_2025_control_project/apps/runners/self_rec/honeypot.py
@@ -13,8 +13,8 @@ from lasr_labs_2025_control_project.apps.protocols.untrusted_monitoring_protocol
 )
 from lasr_labs_2025_control_project.apps.scorers import max_confidence_scorer
 
-untrusted_model = "openai/ft:gpt-4.1-2025-04-14:lasr-labs::CC5IeIFO"
-trusted_model = "openai/gpt-4.1"
+untrusted_model = "openai/gpt-4.1-2025-04-14"
+trusted_model = "openai/gpt-4o-2024-08-06"
 score_field = "confidence_score"
 
 apps_task = get_control_task_product(
@@ -32,5 +32,5 @@ apps_task = get_control_task_product(
     ),
 )
 
-n = 2
-eval = eval(tasks=apps_task, epochs=Epochs(n, [f"pass_at_{n}"]), limit=50)
+n = 1
+eval = eval(tasks=apps_task, epochs=Epochs(n, [f"pass_at_{n}"]), limit=200)

--- a/src/lasr_labs_2025_control_project/apps/runners/self_rec/honeypot.py
+++ b/src/lasr_labs_2025_control_project/apps/runners/self_rec/honeypot.py
@@ -17,6 +17,9 @@ untrusted_model = "openai/gpt-4.1-2025-04-14"
 trusted_model = "openai/gpt-4o-2024-08-06"
 score_field = "confidence_score"
 
+# Toggle monitoring on/off for evaluations
+use_monitor = False
+
 apps_task = get_control_task_product(
     settings=apps_setting,
     protocols=untrusted_monitoring_protocol(
@@ -24,9 +27,10 @@ apps_task = get_control_task_product(
         monitor_builder=untrusted_monitor_builder(
             model=untrusted_model, score_field=score_field
         ),
+        use_monitor=use_monitor,
     ),
     modes=[EvalMode.ATTACK],
-    monitoring_scorers=[max_confidence_scorer()],
+    monitoring_scorers=[max_confidence_scorer()] if use_monitor else [],
     eval_config=ControlEvalConfig(
         untrusted_model=untrusted_model, trusted_model=trusted_model
     ),

--- a/src/lasr_labs_2025_control_project/apps/runners/self_rec/human_honeypot.py
+++ b/src/lasr_labs_2025_control_project/apps/runners/self_rec/human_honeypot.py
@@ -17,6 +17,9 @@ untrusted_model = "openai/gpt-4.1"
 trusted_model = "openai/gpt-4o"
 score_field = "confidence_score"
 
+# Toggle monitoring on/off for evaluations
+use_monitor = False
+
 apps_task = get_control_task_product(
     settings=human_solution_apps_setting,
     protocols=untrusted_monitoring_protocol(
@@ -24,9 +27,10 @@ apps_task = get_control_task_product(
         monitor_builder=untrusted_monitor_builder(
             model=untrusted_model, score_field=score_field
         ),
+        use_monitor=use_monitor,
     ),
     modes=[EvalMode.ATTACK],
-    monitoring_scorers=[max_confidence_scorer()],
+    monitoring_scorers=[max_confidence_scorer()] if use_monitor else [],
     eval_config=ControlEvalConfig(
         untrusted_model=untrusted_model, trusted_model=trusted_model
     ),


### PR DESCRIPTION
I have added a parameter to our control eval runners which lets us toggle the monitor on and off. This is helpful because for some evaluations like the self-rec one, we are wanting to use logprobs which we have scripts that Jonathan created for. We may also want it off for other runs we do at points. PR'ing for review before merging.